### PR TITLE
build(travis-npm-install): set npm install as travis install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
   email: true
 node_js:
   - '8'
+install: npm install
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1


### PR DESCRIPTION
Related to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/156.

Should fix issues with `greenkeeper-lockfile` not updating the lockfile properly for greenkeeper PRs.