### PR TITLE
Fix: superlike API endpoint is to be used with POST, not GET

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class TinderClient {
 
   superLike(userId) {
     return this.client({
-      method: 'get',
+      method: 'post',
       url: `/like/${userId}/super`,
     }).then(response => response.data);
   }


### PR DESCRIPTION
According to https://github.com/fbessez/Tinder, superlike works with POST. 

Tested and working (didn't worked with GET: 404, but works well with POST)