### PR TITLE
Fix eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
 
 {
+  "settings": {
+    "rules": {
+      "quotes": "simple"
+    }
+  },
   "extends": "airbnb-base",
   "env": {
     "jest": true


### PR DESCRIPTION
I use eslint to lint the code and I noticed that you like simple quotes, but this isn't specified in `.eslintrc` file. So, here it is.