### PR TITLE
feat(login): create static constructor that uses Facebook login

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ const facebookToken = 'someFacebookToken';
 const client = await TinderClient.create({ facebookUserId, facebookToken });
 ```
 
+```javascript
+import { TinderClient } from 'tinder-client';
+
+const client = await TinderClient.createFromFacebookLogin({
+  emailAddress: 'your facebook email address',
+  password: 'your facebook password',
+});
+```
+
 ### `getProfile`
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,7 +794,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
       "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -1529,7 +1528,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1788,8 +1786,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2401,8 +2398,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2550,7 +2546,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2669,8 +2664,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -3117,14 +3111,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3296,8 +3288,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "4.0.0",
@@ -3747,14 +3738,12 @@
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -4519,6 +4508,27 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4570,6 +4580,14 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -4772,8 +4790,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.7",
@@ -5438,7 +5455,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5765,7 +5781,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -6007,7 +6022,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6016,8 +6030,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -6438,8 +6451,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -7714,8 +7726,7 @@
     "mime": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
-      "dev": true
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
       "version": "1.37.0",
@@ -7748,7 +7759,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7756,8 +7766,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -7794,7 +7803,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -11216,7 +11224,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -11531,8 +11538,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -11560,6 +11566,11 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -11880,14 +11891,12 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prompts": {
       "version": "2.0.2",
@@ -11898,6 +11907,11 @@
         "kleur": "^3.0.2",
         "sisteransi": "^1.0.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -11926,6 +11940,44 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.12.2.tgz",
+      "integrity": "sha512-xWSyCeD6EazGlfnQweMpM+Hs6X6PhUYhNTHKFj/axNZDq4OmrVERf70isBf7HsnFgB3zOC1+23/8+wCAZYg+Pg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "ws": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
+          "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -12054,7 +12106,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12145,8 +12196,7 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",
@@ -12424,7 +12474,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -12682,8 +12731,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13348,7 +13396,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -13733,6 +13780,16 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "tinder-access-token-generator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tinder-access-token-generator/-/tinder-access-token-generator-1.0.0.tgz",
+      "integrity": "sha512-Akof/XAlOKG8/zDnJIdCl+zvBvyHtbJj1IC8kAGpsycHBnI9gT5zk2BD7Ky9TIJc/wYXMEuwq8hmaoHgFnaGSw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "axios": "^0.18.0",
+        "puppeteer": "^1.12.2"
+      }
+    },
     "tmp": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
@@ -13912,8 +13969,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -14198,8 +14254,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -14491,8 +14546,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -14581,6 +14635,14 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "homepage": "https://github.com/jaebradley/tinder-client#readme",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.18.0",
+    "tinder-access-token-generator": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/index.integration.test.js
+++ b/src/index.integration.test.js
@@ -2,6 +2,8 @@ import axios from 'axios';
 import dotenv from 'dotenv';
 import { TinderClient } from './index';
 
+jest.setTimeout(15000);
+
 dotenv.config();
 
 describe('TinderClient', () => {
@@ -25,9 +27,9 @@ describe('TinderClient', () => {
 
     describe('Profile', () => {
       it('should fetch profile', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const response = await client.getProfile();
         expect(response).toBeDefined();
@@ -36,9 +38,9 @@ describe('TinderClient', () => {
 
     describe('Recommendations', () => {
       it('should fetch recommendations', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const response = await client.getRecommendations();
         expect(response).toBeDefined();
@@ -47,9 +49,9 @@ describe('TinderClient', () => {
 
     describe('User', () => {
       it('should fetch user', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const response = await client.getUser(process.env.TEST_USER_ID);
         expect(response).toBeDefined();
@@ -58,9 +60,9 @@ describe('TinderClient', () => {
 
     describe('Metadata', () => {
       it('should fetch metadata', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const response = await client.getMetadata();
         expect(response).toBeDefined();
@@ -69,9 +71,9 @@ describe('TinderClient', () => {
 
     xdescribe('#like', () => {
       it('likes recommendation', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const recommendations = await client.getRecommendations();
         // eslint-disable-next-line no-underscore-dangle
@@ -83,9 +85,9 @@ describe('TinderClient', () => {
 
     xdescribe('#pass', () => {
       it('passes on recommendation', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const recommendations = await client.getRecommendations();
         // eslint-disable-next-line no-underscore-dangle
@@ -97,9 +99,9 @@ describe('TinderClient', () => {
 
     describe('#temporarilyChangeLocation', () => {
       it('temporarily changes location', async () => {
-        const client = await TinderClient.create({
-          facebookUserId: process.env.FACEBOOK_USER_ID,
-          facebookToken: process.env.FACEBOOK_TOKEN,
+        const client = await TinderClient.createFromFacebookLogin({
+          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+          password: process.env.FACEBOOK_PASSWORD,
         });
         const response = await client.changeLocation({ latitude: 42.3601, longitude: 71.0589 });
         expect(response).toBeDefined();

--- a/src/index.integration.test.js
+++ b/src/index.integration.test.js
@@ -7,11 +7,21 @@ jest.setTimeout(15000);
 dotenv.config();
 
 describe('TinderClient', () => {
-  beforeEach(() => {
+  let client;
+
+  beforeAll(async () => {
     const actualAxios = require.requireActual('axios');
     axios.post.mockImplementation(actualAxios.post);
     axios.create.mockImplementation(actualAxios.create);
     axios.get.mockImplementation(actualAxios.get);
+    client = await TinderClient.createFromFacebookLogin({
+      emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
+      password: process.env.FACEBOOK_PASSWORD,
+    });
+  });
+
+  afterAll(() => {
+    client = null;
   });
 
   describe('Integration tests', () => {
@@ -27,10 +37,6 @@ describe('TinderClient', () => {
 
     describe('Profile', () => {
       it('should fetch profile', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const response = await client.getProfile();
         expect(response).toBeDefined();
       });
@@ -38,10 +44,6 @@ describe('TinderClient', () => {
 
     describe('Recommendations', () => {
       it('should fetch recommendations', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const response = await client.getRecommendations();
         expect(response).toBeDefined();
       });
@@ -49,10 +51,6 @@ describe('TinderClient', () => {
 
     describe('User', () => {
       it('should fetch user', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const response = await client.getUser(process.env.TEST_USER_ID);
         expect(response).toBeDefined();
       });
@@ -60,10 +58,6 @@ describe('TinderClient', () => {
 
     describe('Metadata', () => {
       it('should fetch metadata', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const response = await client.getMetadata();
         expect(response).toBeDefined();
       });
@@ -71,10 +65,6 @@ describe('TinderClient', () => {
 
     xdescribe('#like', () => {
       it('likes recommendation', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const recommendations = await client.getRecommendations();
         // eslint-disable-next-line no-underscore-dangle
         const firstRecommendationUserId = recommendations[0]._id;
@@ -85,10 +75,6 @@ describe('TinderClient', () => {
 
     xdescribe('#pass', () => {
       it('passes on recommendation', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const recommendations = await client.getRecommendations();
         // eslint-disable-next-line no-underscore-dangle
         const firstRecommendationUserId = recommendations[0]._id;
@@ -99,10 +85,6 @@ describe('TinderClient', () => {
 
     describe('#temporarilyChangeLocation', () => {
       it('temporarily changes location', async () => {
-        const client = await TinderClient.createFromFacebookLogin({
-          emailAddress: process.env.FACEBOOK_EMAIL_ADDRESS,
-          password: process.env.FACEBOOK_PASSWORD,
-        });
         const response = await client.changeLocation({ latitude: 42.3601, longitude: 71.0589 });
         expect(response).toBeDefined();
       });
@@ -111,10 +93,6 @@ describe('TinderClient', () => {
     describe('#getUpdates', () => {
       describe('when timestamp is defined', async () => {
         it('gets updates', async () => {
-          const client = await TinderClient.create({
-            facebookUserId: process.env.FACEBOOK_USER_ID,
-            facebookToken: process.env.FACEBOOK_TOKEN,
-          });
           const response = await client.getUpdates('2017-03-25T20:58:00.404Z');
           expect(response).toBeDefined();
         });
@@ -122,10 +100,6 @@ describe('TinderClient', () => {
 
       describe('when timestamp is not defined', async () => {
         it('gets updates', async () => {
-          const client = await TinderClient.create({
-            facebookUserId: process.env.FACEBOOK_USER_ID,
-            facebookToken: process.env.FACEBOOK_TOKEN,
-          });
           const response = await client.getUpdates();
           expect(response).toBeDefined();
         });

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,14 @@ const GENDER_SEARCH_OPTIONS = Object.freeze({
   both: -1,
 });
 
+// Headers from https://github.com/fbessez/Tinder/blob/8bf8612e93702844b640fb2d79b2918238d376e9/tinder_api.py#L7-L13
+const SHARED_HEADERS = Object.freeze({
+  app_version: '6.9.4',
+  platform: 'ios',
+  'User-Agent': 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)',
+  Accept: 'application/json',
+});
+
 class TinderClient {
   constructor(client) {
     if (!client) {
@@ -32,13 +40,9 @@ class TinderClient {
       facebook_token: facebookToken,
     }).then(response => axios.create({
       baseURL: 'https://api.gotinder.com',
-      // https://github.com/fbessez/Tinder/blob/8bf8612e93702844b640fb2d79b2918238d376e9/tinder_api.py#L7-L13
       headers: {
         'X-Auth-Token': response.data.token,
-        app_version: '6.9.4',
-        platform: 'ios',
-        'User-Agent': 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)',
-        Accept: 'application/json',
+        ...SHARED_HEADERS,
       },
     })).then(client => new TinderClient(client));
   }
@@ -49,13 +53,9 @@ class TinderClient {
       facebookPassword: password,
     }).then(accessToken => axios.create({
       baseURL: 'https://api.gotinder.com',
-      // https://github.com/fbessez/Tinder/blob/8bf8612e93702844b640fb2d79b2918238d376e9/tinder_api.py#L7-L13
       headers: {
         'X-Auth-Token': accessToken,
-        app_version: '6.9.4',
-        platform: 'ios',
-        'User-Agent': 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)',
-        Accept: 'application/json',
+        ...SHARED_HEADERS,
       },
     })).then(client => new TinderClient(client));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import generateAccessToken from 'tinder-access-token-generator';
 
 /**
  * https://github.com/fbessez/Tinder
@@ -34,6 +35,23 @@ class TinderClient {
       // https://github.com/fbessez/Tinder/blob/8bf8612e93702844b640fb2d79b2918238d376e9/tinder_api.py#L7-L13
       headers: {
         'X-Auth-Token': response.data.token,
+        app_version: '6.9.4',
+        platform: 'ios',
+        'User-Agent': 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)',
+        Accept: 'application/json',
+      },
+    })).then(client => new TinderClient(client));
+  }
+
+  static createFromFacebookLogin({ emailAddress, password }) {
+    return generateAccessToken({
+      facebookEmailAddress: emailAddress,
+      facebookPassword: password,
+    }).then(accessToken => axios.create({
+      baseURL: 'https://api.gotinder.com',
+      // https://github.com/fbessez/Tinder/blob/8bf8612e93702844b640fb2d79b2918238d376e9/tinder_api.py#L7-L13
+      headers: {
+        'X-Auth-Token': accessToken,
         app_version: '6.9.4',
         platform: 'ios',
         'User-Agent': 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)',


### PR DESCRIPTION
Creates a `static` constructor method, `createFromFacebookLogin` that takes your Facebook email address and password to generate a Tinder client.

Behind the scenes, it uses [`tinder-access-token-generator`](https://www.npmjs.com/package/tinder-access-token-generator) (of which I'm also the author of) to generate the Tinder auth token.

This package uses `puppeteer` to effectively go through the Facebook login flow and token capture featured in [the "Retrieving Facebook User ID and Facebook Access Token" section of the `README`](https://github.com/jaebradley/tinder-client#retrieving-facebook-user-id-and-facebook-access-token).

Facebook, unsurprisingly, has detection in place that can "lock" login attempts into the account when it sees login attempts executed via `puppeteer`. This may cause client construction to fail.

Closes #78.

